### PR TITLE
Feat: forgot/reset password

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,9 +1,0 @@
-# File .env
-POSTGRES_DB=barber_db
-DB_USER=root
-DB_PASSWORD=password1234
-
-JWT_REFRESH_EXPIRATION=1h
-JWT_SECRET_KEY=dfjlksdfjsdkljfkljj
-
-DATABASE_URL="postgresql://root:password1234@localhost:5432/barber_db?schema=public"

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -11,3 +11,6 @@ DB_PASSWORD=qqqqq
 
 JWT_REFRESH_EXPIRATION=1h
 JWT_SECRET_KEY=dfjlksdfjsdkljfkljj
+
+EMAIL_USER=example@gmail.com
+EMAIL_PASS=dgsgsg

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -1,15 +1,13 @@
-# Environment variables declared in this file are automatically made available to Prisma.
-# See the documentation for more detail: https://pris.ly/d/prisma-schema#accessing-environment-variables-from-the-schema
+PORT=3000
 
-# Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
-# See the documentation for all the connection string options: https://pris.ly/d/connection-strings
-
-
-DB_USER=johndoe
-DB_PASSWORD=qqqqq
+POSTGRES_DB=barber_db
+DB_USER=root
+DB_PASSWORD=password1234
 
 JWT_REFRESH_EXPIRATION=1h
 JWT_SECRET_KEY=dfjlksdfjsdkljfkljj
+
+DATABASE_URL="postgresql://root:password1234@localhost:5432/barber_db?schema=public"
 
 EMAIL_USER=example@gmail.com
 EMAIL_PASS=dgsgsg

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -4,7 +4,6 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 
-DATABASE_URL="postgresql://johndoe:qqqqq@localhost:5432/barber-shop?schema=public"
 
 DB_USER=johndoe
 DB_PASSWORD=qqqqq

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -21,6 +21,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^6.9.13",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
@@ -35,6 +36,7 @@
         "@types/jest": "^29.5.2",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "^20.3.1",
+        "@types/nodemailer": "^6.4.15",
         "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -2422,6 +2424,15 @@
       "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.15",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.15.tgz",
+      "integrity": "sha512-0EBJxawVNjPkng1zm2vopRctuWVCxk34JcIlRuXSf54habUWdz1FB7wHDqOqvDa8Mtpt0Q3LTXQkAs2LNyK5jQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/passport": {
@@ -8002,6 +8013,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.13.tgz",
+      "integrity": "sha512-7o38Yogx6krdoBf3jCAqnIN4oSQFx+fMa0I7dK1D+me9kBxx12D+/33wSb+fhOCtIxvYJ+4x4IMEhmhCKfAiOA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^6.9.13",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"
@@ -46,6 +47,7 @@
     "@types/jest": "^29.5.2",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.3.1",
+    "@types/nodemailer": "^6.4.15",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,34 +1,49 @@
-import { Body, Controller, Get, Param, Post, Put } from "@nestjs/common";
+import { Body, Controller, Get, Param, Patch, Post, Put, Req, UseGuards } from '@nestjs/common'
 
-import { Auth, GetUser } from "./decorators";
-import { AuthService } from "./auth.service";
-import { CreateUserDto } from "./dto/create-user.dto";
-import { LoginUserDto } from "./dto/login-user.dto";
-import { User } from "./interfaces";
-import { UpdateUserDto } from "./dto/update-user.dto";
+import { Auth, GetUser } from './decorators'
+import { AuthService } from './auth.service'
+import { CreateUserDto } from './dto/create-user.dto'
+import { LoginUserDto } from './dto/login-user.dto'
+import { User } from './interfaces'
+import { UpdateUserDto } from './dto/update-user.dto'
+import { ForgotPasswordUserDto } from './dto/forgot-password.dto'
+import { ResetPassUserDto } from './dto/reset-password.dto'
+import { Request } from 'express'
+import { JWTAuthGuard } from './guards/reset-pass.guard'
 
-@Controller("auth")
+@Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor (private readonly authService: AuthService) {}
 
-  @Post("new-account")
-  async create(@Body() createAuthDto: CreateUserDto) {
-    return await this.authService.create(createAuthDto);
+  @Post('new-account')
+  async create (@Body() createAuthDto: CreateUserDto) {
+    return await this.authService.create(createAuthDto)
   }
 
-  @Post("login")
-  async login(@Body() loginAuthDto: LoginUserDto) {
-    return await this.authService.login(loginAuthDto);
+  @Post('login')
+  async login (@Body() loginAuthDto: LoginUserDto) {
+    return await this.authService.login(loginAuthDto)
   }
 
-  @Get("renew")
+  @Get('renew')
   @Auth()
-  async renewToken(@GetUser() user: User) {
-    return await this.authService.renewToken(user);
+  async renewToken (@GetUser() user: User) {
+    return await this.authService.renewToken(user)
   }
 
-  @Put(":id")
-  async update(@Param("id") id: string, @Body() updateUserDto: UpdateUserDto) {
-    return await this.authService.update(id, updateUserDto);
+  @Put(':id')
+  async update (@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
+    return await this.authService.update(id, updateUserDto)
+  }
+
+  @Post('forgot-password')
+  async forgotPassword (@Body() email: ForgotPasswordUserDto) {
+    return await this.authService.forgotPassword(email)
+  }
+
+  @Patch('reset-password')
+  @UseGuards(JWTAuthGuard)
+  async resetPassword (@Req() req: Request, @Body() resetPass: ResetPassUserDto) {
+    return await this.authService.resetPassword(resetPass)
   }
 }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -3,7 +3,7 @@ import { PassportModule } from '@nestjs/passport'
 import { Test, type TestingModule } from '@nestjs/testing'
 import { validate } from 'class-validator'
 
-import { hash } from 'bcrypt'
+import { JwtService } from '@nestjs/jwt'
 
 import { type User } from './interfaces'
 import { PrismaService } from '../prisma/prisma.service'
@@ -23,6 +23,7 @@ describe('AuthService', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
+        JwtService,
         AuthService,
         {
           provide: PrismaService,
@@ -79,6 +80,22 @@ describe('AuthService', () => {
 
       expect(user).toEqual(newMockUser)
       expect(typeof token).toBe('string')
+    })
+  })
+
+  describe('forgot password', () => {
+    const mockForgotPassDto = {
+      email: mockUser.email
+    }
+    it('should return an error if no user was found with the same email', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null)
+      await expect(authService.forgotPassword(mockForgotPassDto)).rejects.toThrow(new ConflictException('User not found'))
+    })
+
+    it('should return 200 if the user\'s email is found', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser)
+      const result = await authService.forgotPassword(mockForgotPassDto)
+      expect(result).toEqual('Email succssfully sent')
     })
   })
 })

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -3,64 +3,68 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
-  InternalServerErrorException
-} from "@nestjs/common";
+  InternalServerErrorException,
+  ServiceUnavailableException
+} from '@nestjs/common'
 
-import * as jwt from "jsonwebtoken";
-import { hash, compare } from "bcrypt";
+import * as jwt from 'jsonwebtoken'
+import { hash, compare } from 'bcrypt'
+import { createTransport } from 'nodemailer'
 
-import { type CreateUserDto } from "./dto/create-user.dto";
-import { type LoginUserDto } from "./dto/login-user.dto";
-import { PrismaService } from "../prisma/prisma.service";
-import { type User, type IJwtPayload } from "./interfaces";
-import { UpdateUserDto } from "./dto/update-user.dto";
+import { type CreateUserDto } from './dto/create-user.dto'
+import { type LoginUserDto } from './dto/login-user.dto'
+import { PrismaService } from '../prisma/prisma.service'
+import { type User, type IJwtPayload } from './interfaces'
+import { type UpdateUserDto } from './dto/update-user.dto'
 import { type UUID } from 'crypto'
-
+import { type ForgotPasswordUserDto } from './dto/forgot-password.dto'
+import { type ResetPassUserDto } from './dto/reset-password.dto'
 
 @Injectable()
 export class AuthService {
-  constructor(private readonly prismaService: PrismaService) {}
+  constructor (private readonly prismaService: PrismaService) {}
 
-  async create(createAuthDto: CreateUserDto) {
-    const { email, password, name, phoneNumber } = createAuthDto;
+  async create (createAuthDto: CreateUserDto) {
+    const { email, password, name, phoneNumber } = createAuthDto
 
-    const user = await this.findUserByEmail(email);
+    const user = await this.findUserByEmail(email)
 
-    if (user)
+    if (user) {
       throw new ConflictException(
         `User with email ${email} is already registered`
-      );
-    const hashedPass = await hash(password, 10);
+      )
+    }
+    const hashedPass = await hash(password, 10)
     const { id, role } = await this.prismaService.user.create({
       data: {
         name,
         email,
         phone_number: createAuthDto.phoneNumber,
         password: hashedPass,
-        role: "CLIENT",
-      },
-    });
+        role: 'CLIENT'
+      }
+    })
 
-    return { user: { id, name, email, phoneNumber, role } };
+    return { user: { id, name, email, phoneNumber, role } }
   }
 
-  async findUserByEmail(email: string) {
-    const user = await this.prismaService.user.findUnique({ where: { email } });
-    return user;
+  async findUserByEmail (email: string) {
+    const user = await this.prismaService.user.findUnique({ where: { email } })
+    return user
   }
 
-  async login(loginAuthDto: LoginUserDto) {
-    const { email, password } = loginAuthDto;
+  async login (loginAuthDto: LoginUserDto) {
+    const { email, password } = loginAuthDto
 
-    const user = await this.findUserByEmail(email);
+    const user = await this.findUserByEmail(email)
 
-    if (!user) throw new NotFoundException("User not found");
+    if (!user) throw new NotFoundException('User not found')
 
-    const pass = await compare(password, user.password);
+    const pass = await compare(password, user.password)
 
-    if (!pass) throw new BadRequestException("Invalid credentials");
+    if (!pass) throw new BadRequestException('Invalid credentials')
 
-    const token = await this.generateJwt({ id: user.id });
+    const token = await this.generateJwt({ id: user.id })
 
     return {
       user: {
@@ -71,56 +75,112 @@ export class AuthService {
         is_active: user.is_active,
         is_verified: user.is_verified,
         avatar: user.avatar,
-        role: user.role,
+        role: user.role
       },
-      token,
-    };
+      token
+    }
   }
 
-  async update(
+  async update (
     id: string,
     data: UpdateUserDto
   ): Promise<{
-    name: string;
-    email: string;
-    phone_number: string;
-    avatar: string;
-  }> {
-    const user = await this.prismaService.user.findUnique({ where: { id } });
+      name: string
+      email: string
+      phone_number: string
+      avatar: string
+    }> {
+    const user = await this.prismaService.user.findUnique({ where: { id } })
 
-    if (!user) throw new NotFoundException("User doesn't exist");
+    if (!user) throw new NotFoundException("User doesn't exist")
 
-    return this.prismaService.user.update({
+    return await this.prismaService.user.update({
       where: {
-        id,
+        id
       },
       data,
       select: {
         name: true,
         email: true,
         phone_number: true,
-        avatar: true,
+        avatar: true
+      }
+    })
+  }
+
+  async forgotPassword (email: ForgotPasswordUserDto) {
+    const user = await this.findUserByEmail(email.email)
+
+    if (!user) throw new NotFoundException('User not found')
+    await this.sendEmail(user.id, user.email)
+    return 'Email succssfully sent'
+  }
+
+  async resetPassword (resetPassAuthDto: ResetPassUserDto) {
+    const usr = await this.findUserByEmail(resetPassAuthDto.email)
+
+    if (!usr) throw new NotFoundException('User not found')
+
+    const hashedPass = await hash(resetPassAuthDto.password, 10)
+    await this.prismaService.user.update({
+      where: {
+        id: usr.id
       },
-    });
+      data: {
+        password: hashedPass
+      }
+    })
+    const { id, password, ...user } = usr
+    const token = await this.generateJwt({ id })
+    return {
+      user,
+      token
+    }
   }
 
-  async generateJwt(payload: IJwtPayload) {
+  async generateJwt (payload: IJwtPayload) {
     const token = jwt.sign(payload, process.env.JWT_SECRET_KEY, {
-      expiresIn: process.env.JWT_REFRESH_EXPIRATION,
-    });
-    return token;
+      expiresIn: process.env.JWT_REFRESH_EXPIRATION
+    })
+    return token
   }
 
-  async renewToken(user: User) {
-    const token = await this.generateJwt({ id: user.id });
+  async renewToken (user: User) {
+    const token = await this.generateJwt({ id: user.id })
 
     return {
       user,
-      token,
-    };
+      token
+    }
   }
 
-   async findUserByUUID (id: UUID) {
+  async sendEmail (id: string, email: string) {
+    const token = await this.generateJwt({ id })
+    const transporter = createTransport({
+      host: 'smtp.gmail.com',
+      port: 465,
+      secure: true,
+      auth: {
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASS
+      }
+    })
+    const mailOptions = {
+      from: process.env.EMAIL_USR,
+      to: email,
+      subject: 'Reiniciar contraseña | Barbería',
+      text: `Gracias por usar nuestros servicos. Hemos recibido una solicitud para restablecer la contraseña de tu cuenta. Haz clic a este enlace ${process.env.BASE_URL}/reset-password/${token}. Si no solicitaste este cambio, ignora este correo electrónico.`
+    }
+    if (process.env.NODE_ENV !== 'test') {
+      transporter.sendMail(mailOptions, (error, info) => {
+        if (error) {
+          throw new ServiceUnavailableException('An error occured while sending the email')
+        }
+      })
+    }
+  }
+
+  async findUserByUUID (id: UUID) {
     try {
       return await this.prismaService.user.findUnique({
         where: { id }

--- a/backend/src/auth/dto/forgot-password.dto.ts
+++ b/backend/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator'
+
+export class ForgotPasswordUserDto {
+  @IsEmail()
+  readonly email: string
+}

--- a/backend/src/auth/dto/reset-password.dto.ts
+++ b/backend/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,15 @@
+import { IsEmail, IsStrongPassword } from 'class-validator'
+
+export class ResetPassUserDto {
+  @IsEmail()
+  readonly email: string
+
+  @IsStrongPassword({
+    minLength: 8,
+    minUppercase: 1,
+    minNumbers: 1,
+    minLowercase: 0,
+    minSymbols: 0
+  }, { message: 'The password must have at least 8 characters, 1 uppercase letter and 1 number' })
+  readonly password: string
+}

--- a/backend/src/auth/guards/reset-pass.guard.ts
+++ b/backend/src/auth/guards/reset-pass.guard.ts
@@ -1,0 +1,10 @@
+import { type ExecutionContext, Injectable } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import { type Observable } from 'rxjs'
+
+@Injectable()
+export class JWTAuthGuard extends AuthGuard('jwt') {
+  canActivate (context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    return super.canActivate(context)
+  }
+}


### PR DESCRIPTION
- Agregué nodemailer como dependencia para enviar correos a los clientes.
- Agregué dos controllers, uno de POST, forgot-password, y otro de PATCH, reset-password.
- Agregué JWTAuthGuard para validar el token enviado por el cliente antes de reiniciar la contraseña en reset-password controller.
- Agregué tres servicios in auth.service: 
1. forgot-password: comprueba si existe un cliente con el correo enviado desde el front. Si exisite, llama la funcion sendEmail y si no, returna un error.
2. sendEmail: envia un correo con un enlace (contiene un token) al cliente.
3. reset-password: reinicia la contraseña.
- Actualicé el archivo .env.example con las variables de entorno de nodemailer.
- Agregué dos pruebas unitarias para forgot-password: error si no hay un cliente con el correo enviado y mensaje existo si hay. 