### PR TITLE
Feat: forgot password

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -8,3 +8,6 @@ JWT_REFRESH_EXPIRATION=1h
 JWT_SECRET_KEY=dfjlksdfjsdkljfkljj
 
 DATABASE_URL="postgresql://root:password1234@localhost:5432/barber_db?schema=public"
+
+USER_EMAIL=example@gmail.com
+USER_PASS='random pass'

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -22,6 +22,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "jsonwebtoken": "^9.0.2",
+        "nodemailer": "^6.9.13",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1"
@@ -36,6 +37,7 @@
         "@types/jest": "^29.5.2",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "^20.3.1",
+        "@types/nodemailer": "^6.4.15",
         "@types/passport-jwt": "^4.0.1",
         "@types/supertest": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
@@ -2460,6 +2462,15 @@
       "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.15",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.15.tgz",
+      "integrity": "sha512-0EBJxawVNjPkng1zm2vopRctuWVCxk34JcIlRuXSf54habUWdz1FB7wHDqOqvDa8Mtpt0Q3LTXQkAs2LNyK5jQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/passport": {
@@ -8038,6 +8049,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.13.tgz",
+      "integrity": "sha512-7o38Yogx6krdoBf3jCAqnIN4oSQFx+fMa0I7dK1D+me9kBxx12D+/33wSb+fhOCtIxvYJ+4x4IMEhmhCKfAiOA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "jsonwebtoken": "^9.0.2",
+    "nodemailer": "^6.9.13",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"
@@ -47,6 +48,7 @@
     "@types/jest": "^29.5.2",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.3.1",
+    "@types/nodemailer": "^6.4.15",
     "@types/passport-jwt": "^4.0.1",
     "@types/supertest": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^6.21.0",

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common'
+import { Body, Controller, Get, Param, Patch, Post, Put, Req, UseGuards } from '@nestjs/common'
 
 import { Auth, GetUser } from './decorators'
 import { AuthService } from './auth.service'
@@ -7,6 +7,9 @@ import { LoginUserDto } from './dto/login-user.dto'
 import { User } from './interfaces'
 import { UpdateUserDto } from './dto/update-user.dto'
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger'
+import { ForgotPasswordUserDto } from './dto/forgot-password.dto'
+import { ResetPassUserDto } from './dto/reset-password.dto'
+import { JWTAuthGuard } from './guards/reset-password.guard'
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -36,5 +39,16 @@ export class AuthController {
   @Auth()
   async update (@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
     return await this.authService.update(id, updateUserDto)
+  }
+
+  @Post('forgot-password')
+  async forgotPassword (@Body() email: ForgotPasswordUserDto) {
+    return await this.authService.forgotPassword(email)
+  }
+
+  @Patch('reset-password')
+  @UseGuards(JWTAuthGuard)
+  async resetPassword (@Req() req: Request, @Body() resetPass: ResetPassUserDto) {
+    return await this.authService.resetPassword(resetPass)
   }
 }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -3,8 +3,6 @@ import { PassportModule } from '@nestjs/passport'
 import { Test, type TestingModule } from '@nestjs/testing'
 import { validate } from 'class-validator'
 
-import { hash } from 'bcrypt'
-
 import { type User } from './interfaces'
 import { PrismaService } from '../prisma/prisma.service'
 import { AuthService } from './auth.service'
@@ -79,6 +77,22 @@ describe('AuthService', () => {
 
       expect(user).toEqual(newMockUser)
       expect(typeof token).toBe('string')
+    })
+  })
+
+  describe('forgot password', () => {
+    const mockForgotPassDto = {
+      email: mockUser.email
+    }
+    it('should return an error if no user was found with the same email', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(null)
+      await expect(authService.forgotPassword(mockForgotPassDto)).rejects.toThrow(new ConflictException('User not found'))
+    })
+
+    it('should return 200 if the user\'s email is found', async () => {
+      mockPrisma.user.findUnique.mockResolvedValue(mockUser)
+      const result = await authService.forgotPassword(mockForgotPassDto)
+      expect(result).toEqual('Email succssfully sent')
     })
   })
 })

--- a/backend/src/auth/dto/forgot-password.dto.ts
+++ b/backend/src/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,6 @@
+import { IsEmail } from 'class-validator'
+
+export class ForgotPasswordUserDto {
+  @IsEmail()
+  readonly email: string
+}

--- a/backend/src/auth/dto/reset-password.dto.ts
+++ b/backend/src/auth/dto/reset-password.dto.ts
@@ -1,0 +1,15 @@
+import { IsEmail, IsStrongPassword } from 'class-validator'
+
+export class ResetPassUserDto {
+  @IsEmail()
+  readonly email: string
+
+  @IsStrongPassword({
+    minLength: 8,
+    minUppercase: 1,
+    minNumbers: 1,
+    minLowercase: 0,
+    minSymbols: 0
+  }, { message: 'The password must have at least 8 characters, 1 uppercase letter and 1 number' })
+  readonly password: string
+}

--- a/backend/src/auth/guards/reset-password.guard.ts
+++ b/backend/src/auth/guards/reset-password.guard.ts
@@ -1,0 +1,10 @@
+import { type ExecutionContext, Injectable } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import { type Observable } from 'rxjs'
+
+@Injectable()
+export class JWTAuthGuard extends AuthGuard('jwt') {
+  canActivate (context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    return super.canActivate(context)
+  }
+}


### PR DESCRIPTION
- Agregué nodemailer como dependencia para enviar correos a los clientes.
- Agregué dos controllers, uno de POST, forgot-password, y otro de PATCH, reset-password.
- Agregué JWTAuthGuard para validar el token enviado por el cliente antes de reiniciar la contraseña en reset-password controller.
- Agregué tres servicios in auth.service: 
1. forgot-password: comprueba si existe un cliente con el correo enviado desde el front. Si exisite, llama la funcion sendEmail y si no, returna un error.
2. sendEmail: envia un correo con un enlace (contiene un token) al cliente.
3. reset-password: reinicia la contraseña.
- Actualicé el archivo .env.example con las variables de entorno de nodemailer.
- Agregué dos pruebas unitarias para forgot-password: error si no hay un cliente con el correo enviado y mensaje existo si hay. 